### PR TITLE
code executable from extension properties

### DIFF
--- a/main.py
+++ b/main.py
@@ -36,6 +36,7 @@ class VsFolderExtension(Extension):
         self.home: Optional[PosixPath] = Path.home()
         self.show_hidden: bool = False
         self.code_bin: str = "code"
+        self.in_new_window: bool = False
         self.subscribe(PreferencesEvent, OnLoad())
         self.subscribe(KeywordQueryEvent, KeywordQueryEventListener())
         self.subscribe(ItemEnterEvent, ItemEnterEventListener())
@@ -61,6 +62,11 @@ class OnLoad(EventListener):
         if code_bin:
             logger.debug(f'Setting code_bin as {code_bin}')
             extension.code_bin = code_bin
+
+        extension.in_new_window = event.preferences.get('in_new_window').lower() in (
+            'true', 't', 'y', 'yes', '1'
+        )
+
 
 class KeywordQueryEventListener(EventListener):
 
@@ -97,6 +103,8 @@ class ItemEnterEventListener(EventListener):
         arg = event.get_data()
         if isinstance(arg, OpenFolder):
             cmd = [extension.code_bin]
+            if extension.in_new_window:
+                cmd.append('--add')
             cmd.append(f'{arg.folder}{os.sep}')
             subprocess.run(cmd)
 

--- a/main.py
+++ b/main.py
@@ -35,6 +35,7 @@ class VsFolderExtension(Extension):
         super().__init__()
         self.home: Optional[PosixPath] = Path.home()
         self.show_hidden: bool = False
+        self.code_bin: str = "code"
         self.subscribe(PreferencesEvent, OnLoad())
         self.subscribe(KeywordQueryEvent, KeywordQueryEventListener())
         self.subscribe(ItemEnterEvent, ItemEnterEventListener())
@@ -56,6 +57,10 @@ class OnLoad(EventListener):
             'true', 't', 'y', 'yes', '1'
         )
 
+        code_bin = event.preferences.get('code_bin')
+        if code_bin:
+            logger.debug(f'Setting code_bin as {code_bin}')
+            extension.code_bin = code_bin
 
 class KeywordQueryEventListener(EventListener):
 
@@ -91,8 +96,12 @@ class ItemEnterEventListener(EventListener):
     def on_event(self, event: ItemEnterEvent, extension: VsFolderExtension):
         arg = event.get_data()
         if isinstance(arg, OpenFolder):
-            subprocess.run(['code', f'{arg.folder}{os.sep}'])
+            cmd = [extension.code_bin]
+            cmd.append(f'{arg.folder}{os.sep}')
+            subprocess.run(cmd)
+
             return HideWindowAction()
+
         return RenderResultListAction(
             build_list_of_folders(
                 extension, arg, '', LIMIT_FOLDERS_TO_SHOW

--- a/manifest.json
+++ b/manifest.json
@@ -36,6 +36,14 @@
       "name": "Vscode executable",
       "description": "VSCode / Codium executable file (in path or full path-name)",
       "default_value": "code"
+    },
+    {
+      "id": "in_new_window",
+      "type": "select",
+      "name": "Open in a new window",
+      "description": "Do you want to open in a new window or in existing one?",
+      "default_value": "False",
+      "options": ["False", "True"]
     }
   ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -29,6 +29,13 @@
       "description": "Do you want to see hidden folders?",
       "default_value": "False",
       "options": ["False", "True"]
+    },
+    {
+      "id": "code_bin",
+      "type": "input",
+      "name": "Vscode executable",
+      "description": "VSCode / Codium executable file (in path or full path-name)",
+      "default_value": "code"
     }
   ]
 }


### PR DESCRIPTION
* Now `code` executable can be loaded from extension properties
* Allow to configure in extension properties if directory is opened in main window  or in new one